### PR TITLE
Fixes fd leak in leasedb (ticket #2015)

### DIFF
--- a/src/allmydata/storage/accountant.py
+++ b/src/allmydata/storage/accountant.py
@@ -23,6 +23,7 @@ class Accountant(service.MultiService):
         service.MultiService.__init__(self)
         self._storage_server = storage_server
         self._leasedb = LeaseDB(dbfile)
+        self._leasedb.setServiceParent(self)
         self._active_accounts = weakref.WeakValueDictionary()
         self._anonymous_account = Account(LeaseDB.ANONYMOUS_ACCOUNTID, None,
                                           self._storage_server, self._leasedb)


### PR DESCRIPTION
Brian correctly diagnozed this issue and suggested the fix in Weekly Dev
Chat of 2013-07-09. This patch has been manually tested by Zooko using his
fdleakfinder and a unit test has been added to ensure that database connections
are properly closed. Without this patch, the 1819-cloud-merge branch uses
more than 1020 fds and will start failing on operating systems with a low fds
limit.

The portions affecting leasedb.py were written by Zooko and Daira.
